### PR TITLE
Update sentiment_analysis_with_streamlit.ipynb as v1.0.13 Non-linear SVM (SVC) with XGBoost & hyperparameter tunning

### DIFF
--- a/sentiment_analysis_with_streamlit.ipynb
+++ b/sentiment_analysis_with_streamlit.ipynb
@@ -1,20 +1,62 @@
 '''
-Version v.1.0.12 - Support Vector Machine (SVM)
-Testing on Non-linear SVM (SVC) with XGBoost
+Test 1:
+XGBoost hyperparameter tuning:
+Increase the vectorizer max feature to 15,000 and add trigrams.
 
-XGBoost is a powerful ensemble method that’s less resource-intensive than non-linear SVM.
-Try to replace for SVC to save resources running on Colab.
+Result: GPU power is not enough to run, disconect.
 
-Use RandomizedSearch to reduce compute power need, to fully run on Colab T4 GPU.
+Test 2:
+Test 1 + enable GPU G4
+/usr/local/lib/python3.11/dist-packages/sklearn/model_selection/_search.py:317: UserWarning: The total space of parameters 8 is smaller than n_iter=10. Running 8 iterations. For exhaustive searches, use GridSearchCV.
+  warnings.warn(
+/usr/local/lib/python3.11/dist-packages/xgboost/training.py:183: UserWarning: [04:14:19] WARNING: /workspace/src/common/error_msg.cc:27: The tree method `gpu_hist` is deprecated since 2.0.0. To use GPU training, set the `device` parameter to CUDA instead.
+
+    E.g. tree_method = "hist", device = "cuda"
+
+  bst.update(dtrain, iteration=i, fobj=obj)
+Best Parameters: {'n_estimators': 100, 'max_depth': 5, 'learning_rate': 0.01}
+Best Cross-Validation Accuracy: 0.57
+/usr/local/lib/python3.11/dist-packages/xgboost/training.py:183: UserWarning: [04:14:22] WARNING: /workspace/src/common/error_msg.cc:27: The tree method `gpu_hist` is deprecated since 2.0.0. To use GPU training, set the `device` parameter to CUDA instead.
+
+    E.g. tree_method = "hist", device = "cuda"
+
+  bst.update(dtrain, iteration=i, fobj=obj)
+/usr/local/lib/python3.11/dist-packages/xgboost/core.py:2676: UserWarning: [04:14:27] WARNING: /workspace/src/common/error_msg.cc:27: The tree method `gpu_hist` is deprecated since 2.0.0. To use GPU training, set the `device` parameter to CUDA instead.
+
+    E.g. tree_method = "hist", device = "cuda"
+
+  if len(data.shape) != 1 and self.num_features() != data.shape[1]:
+/usr/local/lib/python3.11/dist-packages/xgboost/core.py:729: UserWarning: [04:14:27] WARNING: /workspace/src/common/error_msg.cc:58: Falling back to prediction using DMatrix due to mismatched devices. This might lead to higher memory usage and slower performance. XGBoost is running on: cuda:0, while the input data is on: cpu.
+Potential solutions:
+- Use a data structure that matches the device ordinal in the booster.
+- Set the device for booster before call to inplace_predict.
+
+This warning will only be shown once.
+
+  return func(**kwargs)
+Test Accuracy: 0.50
+
+Test 3:
+Use tree_method='hist' and device='cuda' for proper GPU support.
+Convert TF-IDF output to dense format for GPU compatibility.
+Reduce max_features to 10,000 and limit to bigrams (ngram_range=(1, 2)) to avoid memory issues.
+Expand param_dist for better tuning.
+Keep the subset approach (subset_size=10000) for tuning, then train on the full dataset.
+
+Result:
+Best Parameters: {'subsample': 0.8, 'n_estimators': 300, 'max_depth': 3, 'learning_rate': 0.2, 'colsample_bytree': 0.8}
+Best Cross-Validation Accuracy: 0.84
+Test Accuracy: 0.87
+
 '''
 
 # Cell 1: Install required libraries
-!pip install streamlit pyngrok pandas numpy scikit-learn nltk seaborn matplotlib xgboost -q
+!pip install streamlit pyngrok pandas numpy scikit-learn nltk seaborn matplotlib xgboost==2.1.1 -q
 !wget -q https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-linux-amd64.tgz
 !tar -xvzf ngrok-v3-stable-linux-amd64.tgz -C /usr/local/bin
 !chmod +x /usr/local/bin/ngrok
 
-# Cell 2: Train XGBoost with tuning
+# Cell 2: Train XGBoost with corrected GPU setup
 import pandas as pd
 import nltk
 from sklearn.feature_extraction.text import TfidfVectorizer
@@ -28,7 +70,7 @@ from scipy.stats import loguniform
 from xgboost import XGBClassifier
 from sklearn.preprocessing import LabelEncoder
 
-# Reinstall nltk to avoid initialization errors
+# Reinstall nltk to ensure clean setup
 !pip install nltk --force-reinstall -q
 nltk.download('stopwords')
 
@@ -43,7 +85,7 @@ def preprocess(text):
     return ' '.join(word.lower() for word in text.split() if word.lower() not in stop_words)
 reviews = reviews.apply(preprocess)
 
-# Convert text to numerical features with n-grams
+# Convert text to numerical features with bigrams
 vectorizer = TfidfVectorizer(max_features=10000, ngram_range=(1, 2))
 X = vectorizer.fit_transform(reviews)
 
@@ -56,24 +98,27 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_
 
 # Use subset for tuning
 subset_size = 10000
-X_train_subset = X_train[:subset_size]
+X_train_subset = X_train[:subset_size].toarray()  # Convert to dense for GPU
 y_train_subset = y_train[:subset_size]
 
-# Tune XGBoost
+# Tune XGBoost with GPU
 param_dist = {
-    'n_estimators': [100, 200],
-    'max_depth': [3, 5],
-    'learning_rate': [0.01, 0.1]
+    'n_estimators': [100, 200, 300],
+    'max_depth': [3, 5, 7],
+    'learning_rate': [0.01, 0.05, 0.1, 0.2],
+    'subsample': [0.6, 0.8, 1.0],
+    'colsample_bytree': [0.6, 0.8, 1.0]
 }
-grid = RandomizedSearchCV(XGBClassifier(random_state=42), param_dist, n_iter=10, cv=5, n_jobs=-1, random_state=42)
+grid = RandomizedSearchCV(XGBClassifier(tree_method='hist', device='cuda', random_state=42),
+                         param_dist, n_iter=10, cv=5, n_jobs=1, random_state=42)
 grid.fit(X_train_subset, y_train_subset)
 print(f"Best Parameters: {grid.best_params_}")
 print(f"Best Cross-Validation Accuracy: {grid.best_score_:.2f}")
 
 # Train on full data
-model = grid.best_estimator_
-model.fit(X_train, y_train)
-predictions = model.predict(X_test)
+model = XGBClassifier(**grid.best_params_, tree_method='hist', device='cuda', random_state=42)
+model.fit(X_train.toarray(), y_train)  # Convert to dense for GPU
+predictions = model.predict(X_test.toarray())
 print(f"Test Accuracy: {accuracy_score(y_test, predictions):.2f}")
 
 # Show confusion matrix
@@ -86,7 +131,7 @@ plt.show()
 
 # Predict on new text
 new_text = ["This movie was amazing!"]
-new_text_transformed = vectorizer.transform(new_text)
+new_text_transformed = vectorizer.transform(new_text).toarray()
 prediction = model.predict(new_text_transformed)[0]
 print(f"Prediction for sample text: {le.inverse_transform([prediction])[0]}")
 
@@ -105,6 +150,7 @@ import pickle
 import nltk
 from nltk.corpus import stopwords
 import string
+import numpy as np
 
 nltk.download('stopwords')
 stop_words = set(stopwords.words('english'))
@@ -129,7 +175,7 @@ user_input = st.text_area("Enter your review:", "Type your movie review here..."
 if st.button("Predict Sentiment"):
     if user_input:
         processed_input = preprocess(user_input)
-        input_vector = vectorizer.transform([processed_input])
+        input_vector = vectorizer.transform([processed_input]).toarray()
         prediction = model.predict(input_vector)[0]
         sentiment = le.inverse_transform([prediction])[0]
         st.write(f"Predicted Sentiment: **{sentiment}**")


### PR DESCRIPTION
Follow-up of v1.0.12 Non-linear SVM (SVC) with XGBoost
Add: Hyperparameter tunning + GPU support

Detail:
Use tree_method='hist' and device='cuda' for proper GPU support.
Convert TF-IDF output to dense format for GPU compatibility.
Reduce max_features to 10,000 and limit to bigrams (ngram_range=(1, 2)) to avoid memory issues.
Expand param_dist for better tuning.
Keep the subset approach (subset_size=10000) for tuning, then train on the full dataset.
